### PR TITLE
Stopped using `is` to compare integers

### DIFF
--- a/src/taskmaster/progressbar.py
+++ b/src/taskmaster/progressbar.py
@@ -23,7 +23,7 @@ class Speed(Widget):
     def update(self, pbar):
         'Updates the widget with the current SI prefixed speed.'
 
-        if self.startval is 0:
+        if self.startval == 0:
             self.startval = pbar.currval
             return 'Rate:  --/s'
 


### PR DESCRIPTION
This wasn't a good practice, and wasn't guaranteed to do what was desired.
