### PR TITLE
Remove gevent_zeromq as deprecated

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -26,7 +26,6 @@ Requirements **should** be handled by setuptools, but if they are not, you will 
 * progressbar
 * pyzmq (zeromq)
 * gevent
-* gevent_zeromq
 
 
 A note on Gevent

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     install_requires=[
         'progressbar',
         'gevent',
-        'gevent_zeromq',
+        'pyzmq',
         # 'pyzmq-static',
     ],
     tests_require=[

--- a/src/taskmaster/client.py
+++ b/src/taskmaster/client.py
@@ -8,7 +8,7 @@ taskmaster.consumer
 
 import cPickle as pickle
 import gevent
-from gevent_zeromq import zmq
+import zmq.green as zmq
 from gevent.queue import Queue
 from taskmaster.constants import DEFAULT_LOG_LEVEL, DEFAULT_CALLBACK_TARGET
 from taskmaster.util import import_target, get_logger

--- a/src/taskmaster/server.py
+++ b/src/taskmaster/server.py
@@ -10,7 +10,7 @@ import cPickle as pickle
 import gevent
 import hashlib
 import sys
-from gevent_zeromq import zmq
+import zmq.green as zmq
 from gevent.queue import Queue, Empty
 from os import path, unlink, rename
 from taskmaster.constants import DEFAULT_LOG_LEVEL, DEFAULT_ITERATOR_TARGET


### PR DESCRIPTION
gevent_zeromq is merged into pyzmq: http://zeromq.github.io/pyzmq/eventloop.html#pyzmq-and-gevent
Fixes #6
